### PR TITLE
Avoid overriding values when not needed. Fixes #2.

### DIFF
--- a/lib/atlas/box_version.rb
+++ b/lib/atlas/box_version.rb
@@ -45,7 +45,9 @@ module Atlas
     # @param attr [String] :version The version number.
     # @param attr [String] :description Description of the box.
     def initialize(tag, hash = {})
-      hash['description'] = hash['description_markdown']
+      if hash.key? 'description_markdown'
+        hash['description'] = hash['description_markdown']
+      end
 
       super(tag, hash)
     end

--- a/spec/box_spec.rb
+++ b/spec/box_spec.rb
@@ -56,10 +56,11 @@ describe Atlas::Box do
     VCR.use_cassette('can_create_version_inside_box') do
       box = Atlas::Box.find('atlas-ruby/example')
 
-      version = box.create_version(version: '1.1.0')
+      version = box.create_version(version: '1.1.0', description: 'New Box')
 
       expect(version).to be_a Atlas::BoxVersion
       expect(version.version).to eq '1.1.0'
+      expect(version.description).to eq 'New Box'
     end
   end
 


### PR DESCRIPTION
If we override description (because we're working around differences in the
request/response) it'll also override our attribute.
