### PR TITLE
Handles the ability to self-host boxes.

### DIFF
--- a/lib/atlas/box_provider.rb
+++ b/lib/atlas/box_provider.rb
@@ -4,7 +4,7 @@ module Atlas
   # @attr_accessor [String] name The name of the provider.
   # @attr_accessor [String] download_url The url to download from.
   class BoxProvider < Resource
-    attr_accessor :name, :download_url
+    attr_accessor :name, :original_url, :download_url, :url
 
     # Find a provider by it's tag.
     #
@@ -42,7 +42,7 @@ module Atlas
     # @param hash [String] :url An HTTP URL to the box file. Omit if uploading
     #   with Atlas.
     def initialize(tag, hash = {})
-      hash[:url] = hash[:download_url]
+      hash[:url] = hash[:download_url] unless hash.key? :url
 
       super(tag, hash)
     end

--- a/spec/cassettes/can_create_self_hosted_provider.yml
+++ b/spec/cassettes/can_create_self_hosted_provider.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/vmware?access_token=test-token
+    body:
+      encoding: UTF-8
+      string: '{"provider":{"name":"vmware","url":"http://boxes.nickcharlton.net.s3.amazonaws.com/trusty64-chef-vmware.box"}}'
+    headers:
+      User-Agent:
+      - Atlas-Ruby/1.2.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: 
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 02 Oct 2015 14:07:50 GMT
+      Server:
+      - Apache
+      Status:
+      - 404 Not Found
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Powered-By:
+      - Phusion Passenger 5.0.16
+      X-Request-Id:
+      - 81193ac2-7fed-4c88-82a2-5fa070c5662e
+      X-Runtime:
+      - '0.063536'
+      X-XSS-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":["Resource not found!"]}'
+    http_version: 
+  recorded_at: Fri, 02 Oct 2015 14:07:51 GMT
+- request:
+    method: post
+    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/providers?access_token=test-token
+    body:
+      encoding: UTF-8
+      string: '{"provider":{"name":"vmware","url":"http://boxes.nickcharlton.net.s3.amazonaws.com/trusty64-chef-vmware.box"}}'
+    headers:
+      User-Agent:
+      - Atlas-Ruby/1.2.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 02 Oct 2015 14:07:51 GMT
+      ETag:
+      - '"2c29d1937fa780215f4306f967ceaa6f"'
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Powered-By:
+      - Phusion Passenger 5.0.16
+      X-Request-Id:
+      - 6d2556b0-1bc0-4b37-a287-aa6dbaebef94
+      X-Runtime:
+      - '0.172749'
+      X-XSS-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"name":"vmware","hosted":false,"hosted_token":null,"original_url":"http://boxes.nickcharlton.net.s3.amazonaws.com/trusty64-chef-vmware.box","created_at":"2015-10-02T14:07:51.787Z","updated_at":"2015-10-02T14:07:51.787Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/vmware.box"}'
+    http_version: 
+  recorded_at: Fri, 02 Oct 2015 14:07:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -40,6 +40,23 @@ describe Atlas::BoxProvider do
     end
   end
 
+  it 'can create a self-hosted provider' do
+    VCR.use_cassette('can_create_self_hosted_provider') do
+      allow(Atlas.client).to receive(:post).and_call_original
+
+      url = 'http://boxes.nickcharlton.net.s3.amazonaws.com/'\
+            'trusty64-chef-vmware.box'
+      provider = Atlas::BoxProvider.create('atlas-ruby/example/1.0.0',
+                                           name: 'vmware',
+                                           url: url)
+
+      expect(provider).to be_a Atlas::BoxProvider
+      expect(provider.name).to eq 'vmware'
+      expect(provider.original_url).to eq url
+      expect(Atlas.client).to have_received(:post)
+    end
+  end
+
   it 'can update an existing provider' do
     VCR.use_cassette('can_update_provider') do
       allow(Atlas.client).to receive(:put).and_call_original


### PR DESCRIPTION
Here, it's necessary to keep hold of the :originaL_url property of the response,
as this is where it ends up. This adds another test case for handling that.
