### PR TITLE
Add timestamps to Box, BoxVersion and BoxProvider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.0 (unreleased)
+
+* Adds timestamps to `Box`, `BoxVersion` and `BoxProvider`.
+
 ## 1.2.1 (03/10/2015)
 
 * Fixes a bug where self-hosted box URLs wouldn't store correctly ([#1][])

--- a/lib/atlas/box.rb
+++ b/lib/atlas/box.rb
@@ -12,6 +12,7 @@ module Atlas
   class Box < Resource
     attr_accessor :name, :username, :short_description, :description,
                   :is_private, :current_version, :versions
+    date_accessor :created_at, :updated_at
 
     # Find a box by it's tag.
     #

--- a/lib/atlas/box_provider.rb
+++ b/lib/atlas/box_provider.rb
@@ -5,6 +5,7 @@ module Atlas
   # @attr_accessor [String] download_url The url to download from.
   class BoxProvider < Resource
     attr_accessor :name, :original_url, :download_url, :url
+    date_accessor :created_at, :updated_at
 
     # Find a provider by it's tag.
     #

--- a/lib/atlas/box_version.rb
+++ b/lib/atlas/box_version.rb
@@ -10,6 +10,7 @@ module Atlas
   class BoxVersion < Resource
     # Properties of the version.
     attr_accessor :version, :description, :status, :providers
+    date_accessor :created_at, :updated_at
 
     # Find a version by it's tag.
     #

--- a/lib/atlas/resource.rb
+++ b/lib/atlas/resource.rb
@@ -1,3 +1,5 @@
+require "date"
+
 module Atlas
   # Base class for representing resources.
   class Resource
@@ -28,6 +30,22 @@ module Atlas
     def inspect
       objects = to_hash.map { |k, v| "#{k}=#{v.inspect}" }.join(' ')
       "#<#{self.class.name}:#{object_id} #{objects}>"
+    end
+
+    class << self
+      def date_writer(*args)
+        args.each do |attr|
+          define_method("#{attr}=".to_sym) do |date|
+            date = date.is_a?(String) ? DateTime.parse(date) : date
+            instance_variable_set("@#{attr}", date)
+          end
+        end
+      end
+
+      def date_accessor(*args)
+        attr_reader(*args)
+        date_writer(*args)
+      end
     end
   end
 end

--- a/spec/box_spec.rb
+++ b/spec/box_spec.rb
@@ -20,7 +20,7 @@ describe Atlas::Box do
     hash = { 'name' => 'example', 'tag' => 'atlas-ruby/example',
              'short_description' => '', 'description_html' => '',
              'description_markdown' => '', 'username' => 'atlas-ruby',
-             'private' => '', 'created_at' => '', 'updated_at' => '' }
+             'private' => '', 'created_at' => nil, 'updated_at' => nil }
     box = Atlas::Box.new('', hash)
 
     expect(box).not_to be_nil

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -19,8 +19,8 @@ describe Atlas::BoxProvider do
 
   it 'can build a provider from a json response' do
     hash = { 'name' => 'vmware', 'hosted' => '', 'hosted_token' => '',
-             'original_url' => '', 'download_url' => '', 'created_at' => '',
-             'updated_at' => '' }
+             'original_url' => '', 'download_url' => '', 'created_at' => nil,
+             'updated_at' => nil }
     user = Atlas::BoxProvider.new('', hash)
 
     expect(user).not_to be_nil

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe Atlas::Resource do
+  context "using the date accessor" do
+    let(:date) { DateTime.new(2016, 02, 15, 14, 49, 54) }
+    let(:resource) do
+      class ExampleResource < Atlas::Resource
+        date_accessor :created_at
+      end
+
+      ExampleResource.new("tag")
+    end
+
+    it "will output a Date object" do
+      resource.created_at = date
+
+      expect(resource.created_at).to eq date
+    end
+
+    it "will convert a String to a Date" do
+      resource.created_at = "2016-02-15T14:49:54Z"
+
+      expect(resource.created_at).to eq date
+    end
+  end
+end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -19,7 +19,7 @@ describe Atlas::BoxVersion do
   it 'can build a provider from a json response' do
     hash = { 'version' => '1.0.0', 'status' => '', 'description_html' => '',
              'description_markdown' => '', 'number' => '', 'release_url' => '',
-             'revoke_url' => '', 'created_at' => '', 'updated_at' => '' }
+             'revoke_url' => '', 'created_at' => nil, 'updated_at' => nil }
     version = Atlas::BoxVersion.new('', hash)
 
     expect(version).not_to be_nil


### PR DESCRIPTION
This allows us to see the date reported by Atlas when they were created or last
updated. The date accessor ensures it's settable and returnable as an actual
Date object.
