### PR TITLE
Update to use new Atlas API URI

### DIFF
--- a/lib/atlas/client.rb
+++ b/lib/atlas/client.rb
@@ -9,7 +9,7 @@ module Atlas
     attr_accessor :url
 
     def initialize(opts = {})
-      @url = opts[:url] || 'https://atlas.hashicorp.com'
+      @url = opts[:url] || 'https://app.vagrantup.com/'
       @access_token = opts[:access_token]
     end
 

--- a/spec/cassettes/can_create_box.yml
+++ b/spec/cassettes/can_create_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box//new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box//new-box?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"box":{"name":"new-box","is_private":null,"description":null}}'
@@ -43,7 +43,7 @@ http_interactions:
   recorded_at: Thu, 23 Jul 2015 10:11:12 GMT
 - request:
     method: post
-    uri: https://atlas.hashicorp.com/api/v1/boxes?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/boxes?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"box":{"name":"new-box","is_private":null,"description":null}}'

--- a/spec/cassettes/can_create_provider.yml
+++ b/spec/cassettes/can_create_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"virtualbox"}}'
@@ -49,7 +49,7 @@ http_interactions:
   recorded_at: Fri, 24 Jul 2015 12:34:42 GMT
 - request:
     method: post
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/providers?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/providers?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"virtualbox"}}'
@@ -91,7 +91,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:34:31.050Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}'
+      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:34:31.050Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 12:34:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_create_provider_inside_version.yml
+++ b/spec/cassettes/can_create_provider_inside_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.1.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.1.0?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -46,12 +46,12 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"version":"1.1.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-27T16:58:07.437Z","updated_at":"2015-07-27T16:58:07.437Z","number":"1.1.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.1.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.1.0/revoke","providers":[]}'
+      string: '{"version":"1.1.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-27T16:58:07.437Z","updated_at":"2015-07-27T16:58:07.437Z","number":"1.1.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.1.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.1.0/revoke","providers":[]}'
     http_version: 
   recorded_at: Mon, 27 Jul 2015 17:07:41 GMT
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.1.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.1.0/provider/virtualbox?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"virtualbox"}}'
@@ -98,7 +98,7 @@ http_interactions:
   recorded_at: Mon, 27 Jul 2015 17:07:42 GMT
 - request:
     method: post
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.1.0/providers?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.1.0/providers?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"virtualbox"}}'
@@ -142,7 +142,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-27T17:07:43.648Z","updated_at":"2015-07-27T17:07:43.648Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.1.0/providers/virtualbox.box"}'
+      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-27T17:07:43.648Z","updated_at":"2015-07-27T17:07:43.648Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.1.0/providers/virtualbox.box"}'
     http_version: 
   recorded_at: Mon, 27 Jul 2015 17:07:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_create_self_hosted_provider.yml
+++ b/spec/cassettes/can_create_self_hosted_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/vmware?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/vmware?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"vmware","url":"http://boxes.nickcharlton.net.s3.amazonaws.com/trusty64-chef-vmware.box"}}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 02 Oct 2015 14:07:51 GMT
 - request:
     method: post
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/providers?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/providers?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"vmware","url":"http://boxes.nickcharlton.net.s3.amazonaws.com/trusty64-chef-vmware.box"}}'
@@ -89,7 +89,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"name":"vmware","hosted":false,"hosted_token":null,"original_url":"http://boxes.nickcharlton.net.s3.amazonaws.com/trusty64-chef-vmware.box","created_at":"2015-10-02T14:07:51.787Z","updated_at":"2015-10-02T14:07:51.787Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/vmware.box"}'
+      string: '{"name":"vmware","hosted":false,"hosted_token":null,"original_url":"http://boxes.nickcharlton.net.s3.amazonaws.com/trusty64-chef-vmware.box","created_at":"2015-10-02T14:07:51.787Z","updated_at":"2015-10-02T14:07:51.787Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/vmware.box"}'
     http_version: 
   recorded_at: Fri, 02 Oct 2015 14:07:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_create_version.yml
+++ b/spec/cassettes/can_create_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.0.0","description":null}}'
@@ -49,7 +49,7 @@ http_interactions:
   recorded_at: Fri, 24 Jul 2015 11:25:42 GMT
 - request:
     method: post
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/versions?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/versions?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.0.0","description":null}}'
@@ -93,7 +93,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"version":"1.0.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:25:32.437Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
+      string: '{"version":"1.0.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:25:32.437Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 11:25:44 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_create_version_inside_box.yml
+++ b/spec/cassettes/can_create_version_inside_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -45,12 +45,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"created_at":"2015-05-13T14:29:39.093Z","updated_at":"2015-07-27T16:08:45.297Z","tag":"atlas-ruby/example","name":"example","short_description":"An
-        example box.","description_html":null,"username":"atlas-ruby","description_markdown":null,"private":false,"current_version":null,"versions":[{"version":"1.0.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-27T16:07:59.632Z","updated_at":"2015-07-27T16:08:45.296Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":true,"hosted_token":"ab2dbcba-f6b6-4f41-a8f1-a01cc3623a62","original_url":null,"created_at":"2015-07-27T16:08:45.265Z","updated_at":"2015-07-27T16:08:45.265Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}]}'
+        example box.","description_html":null,"username":"atlas-ruby","description_markdown":null,"private":false,"current_version":null,"versions":[{"version":"1.0.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-27T16:07:59.632Z","updated_at":"2015-07-27T16:08:45.296Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":true,"hosted_token":"ab2dbcba-f6b6-4f41-a8f1-a01cc3623a62","original_url":null,"created_at":"2015-07-27T16:08:45.265Z","updated_at":"2015-07-27T16:08:45.265Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}]}'
     http_version: 
   recorded_at: Mon, 27 Jul 2015 16:58:05 GMT
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.1.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.1.0?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.1.0","description":null}}'
@@ -97,7 +97,7 @@ http_interactions:
   recorded_at: Mon, 27 Jul 2015 16:58:06 GMT
 - request:
     method: post
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/versions?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/versions?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.1.0","description":null}}'
@@ -141,7 +141,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"version":"1.1.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-27T16:58:07.437Z","updated_at":"2015-07-27T16:58:07.437Z","number":"1.1.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.1.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.1.0/revoke","providers":[]}'
+      string: '{"version":"1.1.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-27T16:58:07.437Z","updated_at":"2015-07-27T16:58:07.437Z","number":"1.1.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.1.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.1.0/revoke","providers":[]}'
     http_version: 
   recorded_at: Mon, 27 Jul 2015 16:58:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_delete_box.yml
+++ b/spec/cassettes/can_delete_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/nickcharlton/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/nickcharlton/new-box?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -51,7 +51,7 @@ http_interactions:
   recorded_at: Thu, 23 Jul 2015 10:11:31 GMT
 - request:
     method: delete
-    uri: https://atlas.hashicorp.com/api/v1/box/nickcharlton/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/nickcharlton/new-box?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/can_delete_provider.yml
+++ b/spec/cassettes/can_delete_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -46,12 +46,12 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:35:05.220Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}'
+      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:35:05.220Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 12:35:41 GMT
 - request:
     method: delete
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -95,7 +95,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:35:05.220Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}'
+      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:35:05.220Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 12:35:43 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_delete_version.yml
+++ b/spec/cassettes/can_delete_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -47,12 +47,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"version":"1.0.0","status":"unreleased","description_html":"<p>This
-        is a description</p>\n","description_markdown":"This is a description","created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:28:17.654Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
+        is a description</p>\n","description_markdown":"This is a description","created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:28:17.654Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 11:31:45 GMT
 - request:
     method: delete
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -95,7 +95,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"version":"1.0.0","status":"unreleased","description_html":"<p>This
-        is a description</p>\n","description_markdown":"This is a description","created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:28:17.654Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
+        is a description</p>\n","description_markdown":"This is a description","created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:28:17.654Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 11:31:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_fetch_box.yml
+++ b/spec/cassettes/can_fetch_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/can_fetch_provider.yml
+++ b/spec/cassettes/can_fetch_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/vmware_desktop?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/vmware_desktop?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -46,7 +46,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"name":"vmware_desktop","hosted":false,"hosted_token":null,"original_url":"http://example.com/boxes/example/1.0.0/vmware_desktop.box","created_at":"2015-05-13T14:45:23.008Z","updated_at":"2015-05-13T14:45:23.008Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/vmware_desktop.box"}'
+      string: '{"name":"vmware_desktop","hosted":false,"hosted_token":null,"original_url":"http://example.com/boxes/example/1.0.0/vmware_desktop.box","created_at":"2015-05-13T14:45:23.008Z","updated_at":"2015-05-13T14:45:23.008Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/vmware_desktop.box"}'
     http_version: 
   recorded_at: Wed, 13 May 2015 14:47:46 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_fetch_user.yml
+++ b/spec/cassettes/can_fetch_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/user/atlas-ruby?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/user/atlas-ruby?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/can_fetch_version.yml
+++ b/spec/cassettes/can_fetch_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"version":"1.0.0","status":"unreleased","description_html":"<p>An
-        initial version.</p>\n","description_markdown":"An initial version.","created_at":"2015-05-13T14:37:42.728Z","updated_at":"2015-05-13T14:37:42.728Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
+        initial version.</p>\n","description_markdown":"An initial version.","created_at":"2015-05-13T14:37:42.728Z","updated_at":"2015-05-13T14:37:42.728Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
     http_version: 
   recorded_at: Wed, 13 May 2015 14:44:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_release_version.yml
+++ b/spec/cassettes/can_release_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -44,12 +44,12 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"version":"1.0.0","status":"unreleased","description_html":null,"description_markdown":"","created_at":"2015-07-24T11:43:17.485Z","updated_at":"2015-07-24T13:11:38.946Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":false,"hosted_token":null,"original_url":"http://example.com/virtualbox.box","created_at":"2015-07-24T13:11:38.918Z","updated_at":"2015-07-24T13:11:38.918Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}'
+      string: '{"version":"1.0.0","status":"unreleased","description_html":null,"description_markdown":"","created_at":"2015-07-24T11:43:17.485Z","updated_at":"2015-07-24T13:11:38.946Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":false,"hosted_token":null,"original_url":"http://example.com/virtualbox.box","created_at":"2015-07-24T13:11:38.918Z","updated_at":"2015-07-24T13:11:38.918Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 13:12:05 GMT
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -93,7 +93,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"version":"1.0.0","status":"active","description_html":null,"description_markdown":"","created_at":"2015-07-24T11:43:17.485Z","updated_at":"2015-07-24T13:11:54.563Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":false,"hosted_token":null,"original_url":"http://example.com/virtualbox.box","created_at":"2015-07-24T13:11:38.918Z","updated_at":"2015-07-24T13:11:38.918Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}'
+      string: '{"version":"1.0.0","status":"active","description_html":null,"description_markdown":"","created_at":"2015-07-24T11:43:17.485Z","updated_at":"2015-07-24T13:11:54.563Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":false,"hosted_token":null,"original_url":"http://example.com/virtualbox.box","created_at":"2015-07-24T13:11:38.918Z","updated_at":"2015-07-24T13:11:38.918Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 13:12:06 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_revoke_version.yml
+++ b/spec/cassettes/can_revoke_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -44,12 +44,12 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"version":"1.0.0","status":"active","description_html":null,"description_markdown":"","created_at":"2015-07-24T11:43:17.485Z","updated_at":"2015-07-24T13:11:54.563Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":false,"hosted_token":null,"original_url":"http://example.com/virtualbox.box","created_at":"2015-07-24T13:11:38.918Z","updated_at":"2015-07-24T13:11:38.918Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}'
+      string: '{"version":"1.0.0","status":"active","description_html":null,"description_markdown":"","created_at":"2015-07-24T11:43:17.485Z","updated_at":"2015-07-24T13:11:54.563Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":false,"hosted_token":null,"original_url":"http://example.com/virtualbox.box","created_at":"2015-07-24T13:11:38.918Z","updated_at":"2015-07-24T13:11:38.918Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 13:19:26 GMT
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -91,7 +91,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"version":"1.0.0","status":"revoked","description_html":null,"description_markdown":"","created_at":"2015-07-24T11:43:17.485Z","updated_at":"2015-07-24T13:19:15.105Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":false,"hosted_token":null,"original_url":"http://example.com/virtualbox.box","created_at":"2015-07-24T13:11:38.918Z","updated_at":"2015-07-24T13:11:38.918Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}'
+      string: '{"version":"1.0.0","status":"revoked","description_html":null,"description_markdown":"","created_at":"2015-07-24T11:43:17.485Z","updated_at":"2015-07-24T13:19:15.105Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[{"name":"virtualbox","hosted":false,"hosted_token":null,"original_url":"http://example.com/virtualbox.box","created_at":"2015-07-24T13:11:38.918Z","updated_at":"2015-07-24T13:11:38.918Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}]}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 13:19:27 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_update_box.yml
+++ b/spec/cassettes/can_update_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/nickcharlton/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/nickcharlton/new-box?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -52,7 +52,7 @@ http_interactions:
   recorded_at: Fri, 24 Jul 2015 10:50:14 GMT
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/nickcharlton/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/nickcharlton/new-box?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"box":{"name":"new-box","short_description":"A short description of

--- a/spec/cassettes/can_update_provider.yml
+++ b/spec/cassettes/can_update_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -44,15 +44,15 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:34:31.050Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}'
+      string: '{"name":"virtualbox","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:34:31.050Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 12:34:56 GMT
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/virtualbox?access_token=test-token
     body:
       encoding: UTF-8
-      string: '{"provider":{"name":"vmware_desktop","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}}'
+      string: '{"provider":{"name":"vmware_desktop","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/virtualbox.box"}}'
     headers:
       User-Agent:
       - Atlas-Ruby/0.1.0
@@ -93,7 +93,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"name":"vmware_desktop","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:34:46.282Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/vmware_desktop.box"}'
+      string: '{"name":"vmware_desktop","hosted":true,"hosted_token":null,"original_url":null,"created_at":"2015-07-24T12:34:31.050Z","updated_at":"2015-07-24T12:34:46.282Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/vmware_desktop.box"}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 12:34:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_update_version.yml
+++ b/spec/cassettes/can_update_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -46,12 +46,12 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"version":"1.0.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:25:32.437Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
+      string: '{"version":"1.0.0","status":"unreleased","description_html":null,"description_markdown":null,"created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:25:32.437Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 11:28:28 GMT
 - request:
     method: put
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0?access_token=test-token
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.0.0","status":"unreleased","description":"This
@@ -97,7 +97,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"version":"1.0.0","status":"unreleased","description_html":"<p>This
-        is a description</p>\n","description_markdown":"This is a description","created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:28:17.654Z","number":"1.0.0","release_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
+        is a description</p>\n","description_markdown":"This is a description","created_at":"2015-07-24T11:25:32.437Z","updated_at":"2015-07-24T11:28:17.654Z","number":"1.0.0","release_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/release","revoke_url":"https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/revoke","providers":[]}'
     http_version: 
   recorded_at: Fri, 24 Jul 2015 11:28:29 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/can_upload_file.yml
+++ b/spec/cassettes/can_upload_file.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/parallels?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/parallels?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''
@@ -49,12 +49,12 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"name":"parallels","hosted":true,"hosted_token":"2e2d83a5-9e61-4913-9614-7224c281d3e6","original_url":null,"created_at":"2016-08-26T18:57:43.326Z","updated_at":"2016-08-26T18:57:43.326Z","download_url":"https://atlas.hashicorp.com/atlas-ruby/boxes/example/versions/1.0.0/providers/parallels.box"}'
+      string: '{"name":"parallels","hosted":true,"hosted_token":"2e2d83a5-9e61-4913-9614-7224c281d3e6","original_url":null,"created_at":"2016-08-26T18:57:43.326Z","updated_at":"2016-08-26T18:57:43.326Z","download_url":"https://app.vagrantup.com/atlas-ruby/boxes/example/versions/1.0.0/providers/parallels.box"}'
     http_version: 
   recorded_at: Mon, 05 Sep 2016 18:05:17 GMT
 - request:
     method: get
-    uri: https://atlas.hashicorp.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/parallels/upload?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example/version/1.0.0/provider/parallels/upload?access_token=test-token
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
(It looks like) HashiCorp have changed the URI of the Vagrant Atlas API.

The old URI redirects to the new one; however, the client [expects](https://github.com/nickcharlton/atlas-ruby/blob/3c73532a7f3387e74257e5649eebb596513229a0/lib/atlas/client.rb#L34) a 2xx HTTP respose. Changing to the new API URI fixes that.

(We've tested this at [The Scale Factory](http://www.scalefactory.com/), and are using the updated code on our own CI infrastructure).

(resubmission of #9, which seemed to have been closed by the rebase I just did)