### PR TITLE
Rename keys in-place to avoid assigning nil.

### DIFF
--- a/lib/atlas.rb
+++ b/lib/atlas.rb
@@ -1,5 +1,6 @@
 require 'excon'
 require 'json'
+require "core_ext/hash_replace_key"
 
 require 'atlas/version'
 require 'atlas/configuration'

--- a/lib/atlas/box.rb
+++ b/lib/atlas/box.rb
@@ -61,8 +61,8 @@ module Atlas
     #
     # @return [Box] a new box object.
     def initialize(tag, hash = {})
-      hash['is_private'] = hash['private']
-      hash['description'] = hash['description_markdown']
+      hash.replace_key!("private", "is_private")
+      hash.replace_key!("description_markdown", "description")
 
       super(tag, hash)
     end

--- a/lib/core_ext/hash_replace_key.rb
+++ b/lib/core_ext/hash_replace_key.rb
@@ -1,0 +1,17 @@
+module HashReplaceKey
+  def replace_key(original, replacement)
+    dup.replace_key!(original, replacement)
+  end
+
+  def replace_key!(original, replacement)
+    return self unless self[original]
+
+    self[replacement] = delete(original)
+
+    self
+  end
+end
+
+class Hash
+  include HashReplaceKey
+end

--- a/spec/core_ext/hash_replace_key_spec.rb
+++ b/spec/core_ext/hash_replace_key_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require "core_ext/hash_replace_key"
+
+RSpec.describe HashReplaceKey do
+  describe "#replace_key" do
+    it "replaces a key with a given replacement and returns a new hash" do
+      original = { foo: "bar" }
+
+      new_hash = original.replace_key(:foo, :baz)
+
+      expect(new_hash).to include(baz: "bar")
+      expect(new_hash).not_to include(foo: "bar")
+      expect(original.object_id).not_to eq(new_hash.object_id)
+    end
+  end
+
+  describe "#replace_key!" do
+    it "replaces a key with a given replacement in place" do
+      original = { foo: "bar" }
+
+      new_hash = original.replace_key!(:foo, :baz)
+
+      expect(new_hash).to include(baz: "bar")
+      expect(new_hash).not_to include(foo: "bar")
+      expect(original.object_id).to eq(new_hash.object_id)
+    end
+
+    it "does nothing if the original key value is nil" do
+      original = { foo: "bar" }
+
+      new_hash = original.replace_key(:baz, :boo)
+
+      expect(original).to eq(new_hash)
+    end
+  end
+end


### PR DESCRIPTION
Some attributes on initial creation have different names when updating
an existing resource. Previously, we were assigning regardless of
whether or not a value in the collection existed, which meant that often
we'd pass `nil` on submission.

This avoids doing that by renaming the key if it exists instead.