### PR TITLE
Check for presence of key, not it's value.

### DIFF
--- a/lib/core_ext/hash_replace_key.rb
+++ b/lib/core_ext/hash_replace_key.rb
@@ -4,7 +4,7 @@ module HashReplaceKey
   end
 
   def replace_key!(original, replacement)
-    return self unless self[original]
+    return self unless has_key?(original)
 
     self[replacement] = delete(original)
 

--- a/spec/core_ext/hash_replace_key_spec.rb
+++ b/spec/core_ext/hash_replace_key_spec.rb
@@ -25,12 +25,20 @@ RSpec.describe HashReplaceKey do
       expect(original.object_id).to eq(new_hash.object_id)
     end
 
-    it "does nothing if the original key value is nil" do
+    it "does nothing if the original key is missing" do
       original = { foo: "bar" }
 
       new_hash = original.replace_key(:baz, :boo)
 
       expect(original).to eq(new_hash)
+    end
+
+    it "copies nil values where the key is present" do
+      original = { bar: nil }
+
+      new_hash = original.replace_key!(:bar, :another)
+
+      expect(new_hash).to include(another: nil)
     end
   end
 end


### PR DESCRIPTION
If you check that there's a falsey value (which includes `nil`), you get
caught out when a key is desired to be `nil`.