### PR TITLE
Refresh box behaviour and cassettes.

### DIFF
--- a/lib/atlas/box.rb
+++ b/lib/atlas/box.rb
@@ -11,7 +11,7 @@ module Atlas
   # @attr_accessor [Array] versions versions associated with this box.
   class Box < Resource
     attr_accessor :name, :username, :short_description, :description,
-                  :is_private, :current_version, :versions
+                  :private, :current_version, :versions
     date_accessor :created_at, :updated_at
 
     requires :username, :name, :short_description, :description
@@ -119,7 +119,9 @@ module Atlas
       begin
         response = Atlas.client.put(url_builder.box_url, body: body)
       rescue Atlas::Errors::NotFoundError
-        response = Atlas.client.post('/boxes', body: body)
+        body[:box].replace_key!(:private, :is_private)
+
+        response = Atlas.client.post("/boxes", body: body)
       end
 
       # trigger the same on versions

--- a/spec/box_spec.rb
+++ b/spec/box_spec.rb
@@ -28,22 +28,46 @@ describe Atlas::Box do
     expect(box.username).to eq 'atlas-ruby'
   end
 
-  it "can create a box" do
-    VCR.use_cassette("can_create_box") do
-      box = Atlas::Box.create(
-        name: "new-box",
-        username: "atlas-ruby",
-        short_description: "A new box",
-        description: "A new box",
-      )
+  describe "#create" do
+    it "creates a private box by default" do
+      VCR.use_cassette("can_create_box") do
+        box = Atlas::Box.create(
+          name: "new-box",
+          username: "atlas-ruby",
+          short_description: "A new box",
+          description: "A new box",
+        )
 
-      expect(box).to be_a(Atlas::Box)
-      expect(box).to have_attributes(
-        name: "new-box",
-        username: "atlas-ruby",
-        short_description: "A new box",
-        description: "A new box",
-      )
+        expect(box).to be_a(Atlas::Box)
+        expect(box).to have_attributes(
+          name: "new-box",
+          username: "atlas-ruby",
+          short_description: "A new box",
+          description: "A new box",
+          private: true,
+        )
+      end
+    end
+
+    it "adjusts the private call when creating a public box" do
+      VCR.use_cassette("can_create_public_box") do
+        box = Atlas::Box.create(
+          name: "new-public-box",
+          username: "atlas-ruby",
+          short_description: "A new box",
+          description: "A new box",
+          private: false,
+        )
+
+        expect(box).to be_a(Atlas::Box)
+        expect(box).to have_attributes(
+          name: "new-public-box",
+          username: "atlas-ruby",
+          short_description: "A new box",
+          description: "A new box",
+          private: false,
+        )
+      end
     end
   end
 

--- a/spec/cassettes/can_create_public_box.yml
+++ b/spec/cassettes/can_create_public_box.yml
@@ -2,11 +2,11 @@
 http_interactions:
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-public-box?access_token=test-token
     body:
       encoding: UTF-8
-      string: '{"box":{"name":"new-box","username":"atlas-ruby","short_description":"A
-        new box","description":"A new box"}}'
+      string: '{"box":{"name":"new-public-box","username":"atlas-ruby","short_description":"A
+        new box","description":"A new box","private":false}}'
     headers:
       User-Agent:
       - Atlas-Ruby/1.6.0
@@ -20,7 +20,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Sun, 18 Mar 2018 21:19:13 GMT
+      - Sun, 18 Mar 2018 21:28:52 GMT
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -36,26 +36,26 @@ http_interactions:
       Cache-Control:
       - no-cache
       Set-Cookie:
-      - _atlas_session_data=UDR3aDdoTEZ0WEZoNDU5S2c1dGJ1TjIvTVMxZG5BekZpQkJ3Tk1lSlEwZXlhVmYra0hTdlpEeUplU1NuSk9PVEtyU3FCSElzL1hGSHMvVzFYc0l4Rnc9PS0tVHE1NkszWXRtaFRKdlUyL0JaZ0lpQT09--7e3200a05bebac91ec72fee4809d2d794a71f8e3;
-        path=/; expires=Tue, 17 Apr 2018 21:19:14 -0000; secure; HttpOnly
+      - _atlas_session_data=dWNUamhmaFhkZ1JQUVUvWDBMTlBGcGl3RExzRG5VWjlxWEF3V3dYUTJ5WGdiVGx5N09SRDJmRFVzUklkVEtSbmkxOFV0WU9xMkpNVW5zcFRhSmpiL3c9PS0td05EOE1VUk5mUDZmZDdFcHlhRWxodz09--670219f79771c84a6194d03232312d03ff24ee9f;
+        path=/; expires=Tue, 17 Apr 2018 21:28:52 -0000; secure; HttpOnly
       X-Request-Id:
-      - e33beed2-9269-4175-81a3-9594d7304ef8
+      - 2fcd144b-96bd-4ed4-a2f6-2af51357b068
       X-Runtime:
-      - '0.269062'
+      - '0.235631'
       Via:
       - 1.1 vegur
     body:
       encoding: ASCII-8BIT
       string: '{"errors":["Resource not found!"],"success":false}'
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:19:14 GMT
+  recorded_at: Sun, 18 Mar 2018 21:28:52 GMT
 - request:
     method: post
     uri: https://app.vagrantup.com/api/v1/boxes?access_token=test-token
     body:
       encoding: UTF-8
-      string: '{"box":{"name":"new-box","username":"atlas-ruby","short_description":"A
-        new box","description":"A new box"}}'
+      string: '{"box":{"name":"new-public-box","username":"atlas-ruby","short_description":"A
+        new box","description":"A new box","is_private":false}}'
     headers:
       User-Agent:
       - Atlas-Ruby/1.6.0
@@ -69,7 +69,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Sun, 18 Mar 2018 21:19:25 GMT
+      - Sun, 18 Mar 2018 21:28:58 GMT
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -83,23 +83,23 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"e311e27a7f8fd0450f7250afafa8ec51"
+      - W/"47ea3ce056ab91ae14a58c1d62261389"
       Cache-Control:
       - max-age=0, private, must-revalidate
       Set-Cookie:
-      - _atlas_session_data=L1RHYVlLWXNzNzNzRVQ3emRVSm9vYzUvYUVlZEpCNTYwM1A4Zk55K1BHYz0tLU5IbzNVaE1GZFpxN3FvTzZwSWNFeVE9PQ%3D%3D--f6473b5977dae5c7aa0f1a412283ab9beb6ce817;
+      - _atlas_session_data=N2k2eUxNbmlJaTRqUzhFam45N1UwRDN2K2NsbEcydXV3c2pPSXhkWnVxST0tLVNiTU9iOGMrM1pPS1JXU3NuWXk5eUE9PQ%3D%3D--6202b2b9295d2229fa925b9b6ee2fd9620b299c1;
         path=/
       X-Request-Id:
-      - 524d3d9d-8bd3-4e4b-b444-9572bf7849ad
+      - ae5e5988-6c4f-4a7c-a958-eafff1aa695a
       X-Runtime:
-      - '0.320831'
+      - '0.285334'
       Via:
       - 1.1 vegur
     body:
       encoding: ASCII-8BIT
-      string: '{"created_at":"2018-03-18T21:19:25.444Z","updated_at":"2018-03-18T21:19:25.444Z","tag":"atlas-ruby/new-box","name":"new-box","short_description":"A
+      string: '{"created_at":"2018-03-18T21:28:59.736Z","updated_at":"2018-03-18T21:28:59.736Z","tag":"atlas-ruby/new-public-box","name":"new-public-box","short_description":"A
         new box","description_html":"<p>A new box</p>\n","username":"atlas-ruby","description_markdown":"A
-        new box","private":true,"current_version":null,"versions":[]}'
+        new box","private":false,"current_version":null,"versions":[]}'
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:19:25 GMT
+  recorded_at: Sun, 18 Mar 2018 21:28:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/can_delete_box.yml
+++ b/spec/cassettes/can_delete_box.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Atlas-Ruby/0.1.0
+      - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
   response:
@@ -16,39 +16,42 @@ http_interactions:
       code: 200
       message: 
     headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 23 Jul 2015 10:11:20 GMT
-      ETag:
-      - '"6dfb0b9ee9e6b236f909bebc5133f43c"'
       Server:
-      - Apache/2.2.22 (Ubuntu) Phusion_Passenger/5.0.10
-      Status:
-      - 200 OK
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Powered-By:
-      - Phusion Passenger 5.0.10
-      X-Request-Id:
-      - e9764c6c-25d0-4436-bc03-16c8abcd03b9
-      X-Runtime:
-      - '0.071101'
-      X-XSS-Protection:
-      - 1; mode=block
-      Content-Length:
-      - '282'
+      - Cowboy
+      Date:
+      - Sun, 18 Mar 2018 21:37:39 GMT
       Connection:
       - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"0b574002c0aa44c2ace28605dffb8624"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _atlas_session_data=VHBJa2hjelNvUGd1SldUeVlMS1BDaC8zeG8rMEkxYzFsbVlTQVRHcUh6RT0tLStsYVRIcGRCeGh4YzQ5dGdUaXpkclE9PQ%3D%3D--a40fb518c13ccf318baf2929dbd5fa7bb990ad1d;
+        path=/
+      X-Request-Id:
+      - f1fe4569-3f52-425c-89b8-24b13ca8d093
+      X-Runtime:
+      - '0.339218'
+      Via:
+      - 1.1 vegur
     body:
-      encoding: UTF-8
-      string: '{"created_at":"2015-07-23T10:11:02.176Z","updated_at":"2015-07-23T10:11:02.176Z","tag":"nickcharlton/new-box","name":"new-box","short_description":null,"description_html":null,"username":"nickcharlton","description_markdown":null,"private":null,"current_version":null,"versions":[]}'
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2018-03-18T21:19:25.444Z","updated_at":"2018-03-18T21:19:25.444Z","tag":"atlas-ruby/new-box","name":"new-box","short_description":"A
+        short description of this box.","description_html":"<p>A new box</p>\n","username":"atlas-ruby","description_markdown":"A
+        new box","private":true,"current_version":null,"versions":[]}'
     http_version: 
-  recorded_at: Thu, 23 Jul 2015 10:11:31 GMT
+  recorded_at: Sun, 18 Mar 2018 21:37:40 GMT
 - request:
     method: delete
     uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box?access_token=test-token
@@ -57,7 +60,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Atlas-Ruby/0.1.0
+      - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
   response:
@@ -65,37 +68,40 @@ http_interactions:
       code: 200
       message: 
     headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 23 Jul 2015 10:11:21 GMT
-      ETag:
-      - '"6dfb0b9ee9e6b236f909bebc5133f43c"'
       Server:
-      - Apache/2.2.22 (Ubuntu) Phusion_Passenger/5.0.10
-      Status:
-      - 200 OK
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Powered-By:
-      - Phusion Passenger 5.0.10
-      X-Request-Id:
-      - 97a7f9a9-6b79-40c0-9703-fa5bff97212d
-      X-Runtime:
-      - '0.230532'
-      X-XSS-Protection:
-      - 1; mode=block
-      Content-Length:
-      - '282'
+      - Cowboy
+      Date:
+      - Sun, 18 Mar 2018 21:37:40 GMT
       Connection:
       - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"0b574002c0aa44c2ace28605dffb8624"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _atlas_session_data=T1dmU3QvSW5xUWZ0V2RUcEhLdHZQQ2lUUG1KUzA0SW80aUwxREtmZXgxST0tLUV2VVV4UFlTRFJxUWdZalBlc3BLeFE9PQ%3D%3D--66e4e2fd1412466e38b8f460de57f130fefa6745;
+        path=/
+      X-Request-Id:
+      - 90249b42-c67a-4a23-ab00-c576cd77953f
+      X-Runtime:
+      - '0.294086'
+      Via:
+      - 1.1 vegur
     body:
-      encoding: UTF-8
-      string: '{"created_at":"2015-07-23T10:11:02.176Z","updated_at":"2015-07-23T10:11:02.176Z","tag":"nickcharlton/new-box","name":"new-box","short_description":null,"description_html":null,"username":"nickcharlton","description_markdown":null,"private":null,"current_version":null,"versions":[]}'
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2018-03-18T21:19:25.444Z","updated_at":"2018-03-18T21:19:25.444Z","tag":"atlas-ruby/new-box","name":"new-box","short_description":"A
+        short description of this box.","description_html":"<p>A new box</p>\n","username":"atlas-ruby","description_markdown":"A
+        new box","private":true,"current_version":null,"versions":[]}'
     http_version: 
-  recorded_at: Thu, 23 Jul 2015 10:11:32 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Sun, 18 Mar 2018 21:37:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/can_fetch_box.yml
+++ b/spec/cassettes/can_fetch_box.yml
@@ -8,46 +8,47 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Atlas-Ruby/0.1.0
+      - Atlas-Ruby/1.6.0
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
   response:
     status:
       code: 200
       message: 
     headers:
-      cache-control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 13 May 2015 14:33:32 GMT
-      etag:
-      - '"87bab070107e515e7f57bc7392e8cea5"'
       Server:
-      - Apache/2.2.22 (Ubuntu) Phusion_Passenger/5.0.6
-      Status:
-      - 200 OK
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      X-Powered-By:
-      - Phusion Passenger 5.0.6
-      x-request-id:
-      - 535b572c-73a0-47fb-8839-db591c1f07cf
-      x-runtime:
-      - '0.595915'
-      x-xss-protection:
-      - 1; mode=block
-      Content-Length:
-      - '292'
+      - Cowboy
+      Date:
+      - Wed, 14 Feb 2018 17:12:32 GMT
       Connection:
       - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"70992750ad3a2dcce1b754fb99d9932a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _atlas_session_data=K2JaSjFHSWh4eFBsdlVLRlRYVXp2MmM4MmtOb1RFQzZmMlhXVXdzY0R5Zz0tLWxsT3Q0Q1k2aE0xSHF0TzN2a00vSlE9PQ%3D%3D--5e529970594aff341492873ba09bc732bf1db7a9;
+        path=/
+      X-Request-Id:
+      - 54cace63-8ff8-4588-802c-b88a11e201ee
+      X-Runtime:
+      - '0.341584'
+      Via:
+      - 1.1 vegur
     body:
-      encoding: UTF-8
-      string: '{"created_at":"2015-05-13T14:29:39.093Z","updated_at":"2015-05-13T14:29:39.093Z","tag":"atlas-ruby/example","name":"example","short_description":"An
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2015-05-13T14:29:39.093Z","updated_at":"2018-02-14T07:42:23.230Z","tag":"atlas-ruby/example","name":"example","short_description":"An
         example box.","description_html":null,"username":"atlas-ruby","description_markdown":null,"private":false,"current_version":null,"versions":[]}'
     http_version: 
-  recorded_at: Wed, 13 May 2015 14:33:33 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 14 Feb 2018 17:12:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/can_update_box.yml
+++ b/spec/cassettes/can_update_box.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Atlas-Ruby/0.1.0
+      - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
   response:
@@ -16,50 +16,54 @@ http_interactions:
       code: 200
       message: 
     headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 24 Jul 2015 10:50:02 GMT
-      ETag:
-      - '"4b33fd02a4d8013b653720a24cb56629"'
       Server:
-      - Apache/2.2.22 (Ubuntu) Phusion_Passenger/5.0.10
-      Status:
-      - 200 OK
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Powered-By:
-      - Phusion Passenger 5.0.10
-      X-Request-Id:
-      - cfc65006-1465-4f33-8588-7be557c6d3cc
-      X-Runtime:
-      - '0.081708'
-      X-XSS-Protection:
-      - 1; mode=block
-      Content-Length:
-      - '302'
+      - Cowboy
+      Date:
+      - Sun, 18 Mar 2018 21:36:50 GMT
       Connection:
       - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"e311e27a7f8fd0450f7250afafa8ec51"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _atlas_session_data=MkNIcmxxUzNpUVEzZ3V3M3hpaXJuMm1DRnNmNFlteC9ia2FnNkVuR1Urcz0tLVRKZjhRYkdyL2ZndGR4QTNuUjloeWc9PQ%3D%3D--925e13f0b8eef8cfd8cccb9282a89ca7b3e93531;
+        path=/
+      X-Request-Id:
+      - 722af3d3-be4f-4d9e-86ba-f71595979160
+      X-Runtime:
+      - '0.256048'
+      Via:
+      - 1.1 vegur
     body:
-      encoding: UTF-8
-      string: '{"created_at":"2015-07-24T10:49:51.842Z","updated_at":"2015-07-24T10:49:51.842Z","tag":"nickcharlton/new-box","name":"new-box","short_description":"Something,
-        something.","description_html":"<p>A new box</p>\n","username":"nickcharlton","description_markdown":"A new box","private":false,"current_version":null,"versions":[]}'
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2018-03-18T21:19:25.444Z","updated_at":"2018-03-18T21:19:25.444Z","tag":"atlas-ruby/new-box","name":"new-box","short_description":"A
+        new box","description_html":"<p>A new box</p>\n","username":"atlas-ruby","description_markdown":"A
+        new box","private":true,"current_version":null,"versions":[]}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:50:14 GMT
+  recorded_at: Sun, 18 Mar 2018 21:36:50 GMT
 - request:
     method: put
     uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box?access_token=test-token
     body:
       encoding: UTF-8
-      string: '{"box":{"name":"new-box","short_description":"A short description of
-        this box.","username":"nickcharlton","current_version":null,"is_private":false,"description":null}}'
+      string: '{"box":{"created_at":"2018-03-18 21:19:25 UTC","updated_at":"2018-03-18
+        21:19:25 UTC","name":"new-box","short_description":"A short description of
+        this box.","username":"atlas-ruby","current_version":null,"description":"A
+        new box"}}'
     headers:
       User-Agent:
-      - Atlas-Ruby/0.1.0
+      - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
   response:
@@ -67,38 +71,40 @@ http_interactions:
       code: 200
       message: 
     headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 24 Jul 2015 10:50:03 GMT
-      ETag:
-      - '"f288f525d60709042450f794af7efbe2"'
       Server:
-      - Apache/2.2.22 (Ubuntu) Phusion_Passenger/5.0.10
-      Status:
-      - 200 OK
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Powered-By:
-      - Phusion Passenger 5.0.10
-      X-Request-Id:
-      - cf3ae6df-fddc-4f52-8b77-116a4745726e
-      X-Runtime:
-      - '0.081042'
-      X-XSS-Protection:
-      - 1; mode=block
-      Content-Length:
-      - '313'
+      - Cowboy
+      Date:
+      - Sun, 18 Mar 2018 21:36:51 GMT
       Connection:
       - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"0b574002c0aa44c2ace28605dffb8624"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _atlas_session_data=aGxoUDNPUkh3dW5YZXpTanVXVTRhdFlRWTB3ZTBScW43UjJQaHJ0ajNlRT0tLXQwNlNuQVVtMEtDN2I4SFRTM3owcmc9PQ%3D%3D--46bcd493ee0314ccd1bfd67cb01d8850b028bfba;
+        path=/
+      X-Request-Id:
+      - 26a08d34-a7dc-4e3f-9107-0740c1346384
+      X-Runtime:
+      - '0.282881'
+      Via:
+      - 1.1 vegur
     body:
-      encoding: UTF-8
-      string: '{"created_at":"2015-07-24T10:49:51.842Z","updated_at":"2015-07-24T10:49:51.842Z","tag":"nickcharlton/new-box","name":"new-box","short_description":"A
-        short description of this box.","description_html":null,"username":"nickcharlton","description_markdown":null,"private":false,"current_version":null,"versions":[]}'
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2018-03-18T21:19:25.444Z","updated_at":"2018-03-18T21:19:25.444Z","tag":"atlas-ruby/new-box","name":"new-box","short_description":"A
+        short description of this box.","description_html":"<p>A new box</p>\n","username":"atlas-ruby","description_markdown":"A
+        new box","private":true,"current_version":null,"versions":[]}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:50:15 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Sun, 18 Mar 2018 21:36:51 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
* Boxes are now created as private by default.
* Renames the internal attribute `is_private` to `private`, to closer
  mimic the return data.
* On initial creation, ensures `is_private` is sent with the response
  body.
* Moves boxes maintained to the `atlas-ruby` namespace.
* Refreshes the fresh create, update and delete cassettes.