### PR TITLE
Switch to providing tokens in the header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or install it yourself as:
 ```ruby
 # first, login with the token from Atlas
 Atlas.configure do |config|
-  config.access_token = 'token'
+  config.token = "test-token"
 end
 
 # then you can load in users (creating, updating, etc isn't supported by Atlas)

--- a/lib/atlas.rb
+++ b/lib/atlas.rb
@@ -19,6 +19,6 @@ module Atlas
   attr_accessor :client
 
   def self.client
-    @client ||= Client.new(access_token: configuration.access_token)
+    @client ||= Client.new(token: configuration.token)
   end
 end

--- a/lib/atlas/client.rb
+++ b/lib/atlas/client.rb
@@ -10,7 +10,7 @@ module Atlas
 
     def initialize(opts = {})
       @url = opts[:url] || 'https://app.vagrantup.com/'
-      @access_token = opts[:access_token]
+      @token = opts[:token]
     end
 
     %w(get put post delete).each do |m|
@@ -21,6 +21,8 @@ module Atlas
 
     private
 
+    attr_reader :token
+
     def request(method, path, opts = {}) # rubocop:disable AbcSize, MethodLength
       body, query, headers = parse_opts(opts)
 
@@ -28,7 +30,7 @@ module Atlas
       headers.merge!(DEFAULT_HEADERS)
 
       # set the access token
-      query.merge!(access_token: @access_token)
+      headers["Authorization"] = "Bearer #{token}"
 
       connection = Excon.new(@url)
       response = connection.request(expects: [200, 201], method: method,

--- a/lib/atlas/configuration.rb
+++ b/lib/atlas/configuration.rb
@@ -2,27 +2,40 @@ module Atlas
   # Configuration handling for Atlas.
   class Configuration
     # Access token for Atlas
-    attr_accessor :access_token
+    attr_accessor :token
 
     # Create a new Configuration instance
     #
     # This also allows providing a hash of configuration values, which calls
     # the accessor methods to full in the values.
     def initialize(opts = {})
-      opts.each do |k, v|
-        send("#{k}=".to_sym, v)
+      opts.each do |key, value|
+        if key.eql?(:access_token)
+          key = "token"
+          warn "WARNING: Setting the `:access_token` option is " \
+               "deprecated, use `:token` instead"
+        end
+
+        send("#{key}=".to_sym, value)
       end
     end
 
     # Hash representation of the configuration object.
     def to_h
-      { access_token: @access_token }
+      { token: @token }
     end
 
     # String representation of the configuration.
     def to_s
       objects = to_h.collect { |k, v| "#{k}=#{v}" }.join(' ')
       "#<#{self.class.name}:#{object_id} #{objects}"
+    end
+
+    def access_token=(access_token)
+      warn "WARNING: Setting the `:access_token` option is " \
+           "deprecated, use `:token` instead"
+
+      @token = access_token
     end
   end
 

--- a/spec/box_spec.rb
+++ b/spec/box_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Atlas::Box do
   before do
     Atlas.configure do |config|
-      config.access_token = 'test-token'
+      config.token = "test-token"
     end
   end
 

--- a/spec/cassettes/can_create_box.yml
+++ b/spec/cassettes/can_create_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box
     body:
       encoding: UTF-8
       string: '{"box":{"name":"new-box","username":"atlas-ruby","short_description":"A
@@ -12,6 +12,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 404
@@ -51,7 +53,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 21:19:14 GMT
 - request:
     method: post
-    uri: https://app.vagrantup.com/api/v1/boxes?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/boxes
     body:
       encoding: UTF-8
       string: '{"box":{"name":"new-box","username":"atlas-ruby","short_description":"A
@@ -61,6 +63,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_create_provider.yml
+++ b/spec/cassettes/can_create_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"virtualbox","url":null}}'
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 404
@@ -50,7 +52,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 22:47:13 GMT
 - request:
     method: post
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/providers?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/providers
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"virtualbox","url":null}}'
@@ -59,6 +61,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_create_provider_inside_version.yml
+++ b/spec/cassettes/can_create_provider_inside_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.1.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.1.0
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -52,7 +54,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 23:10:46 GMT
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.1.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.1.0/provider/virtualbox
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"virtualbox","url":null}}'
@@ -61,6 +63,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 404
@@ -100,7 +104,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 23:10:47 GMT
 - request:
     method: post
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.1.0/providers?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.1.0/providers
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"virtualbox","url":null}}'
@@ -109,6 +113,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_create_public_box.yml
+++ b/spec/cassettes/can_create_public_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-public-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-public-box
     body:
       encoding: UTF-8
       string: '{"box":{"name":"new-public-box","username":"atlas-ruby","short_description":"A
@@ -12,6 +12,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 404
@@ -51,7 +53,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 21:28:52 GMT
 - request:
     method: post
-    uri: https://app.vagrantup.com/api/v1/boxes?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/boxes
     body:
       encoding: UTF-8
       string: '{"box":{"name":"new-public-box","username":"atlas-ruby","short_description":"A
@@ -61,6 +63,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_create_self_hosted_provider.yml
+++ b/spec/cassettes/can_create_self_hosted_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/vmware?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/vmware
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"vmware","url":"http://boxes.nickcharlton.net.s3.amazonaws.com/trusty64-chef-vmware.box"}}'
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 404
@@ -50,7 +52,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 22:59:11 GMT
 - request:
     method: post
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/providers?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/providers
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"vmware","url":"http://boxes.nickcharlton.net.s3.amazonaws.com/trusty64-chef-vmware.box"}}'
@@ -59,6 +61,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_create_version.yml
+++ b/spec/cassettes/can_create_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.0.0"}}'
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 404
@@ -50,7 +52,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 22:18:23 GMT
 - request:
     method: post
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/versions?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/versions
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.0.0"}}'
@@ -59,6 +61,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_create_version_inside_box.yml
+++ b/spec/cassettes/can_create_version_inside_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -54,7 +56,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 22:37:45 GMT
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.1.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.1.0
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.1.0","description":"New Box"}}'
@@ -63,6 +65,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 404
@@ -102,7 +106,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 22:37:46 GMT
 - request:
     method: post
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/versions?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/versions
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.1.0","description":"New Box"}}'
@@ -111,6 +115,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_delete_box.yml
+++ b/spec/cassettes/can_delete_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -54,7 +56,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 21:37:40 GMT
 - request:
     method: delete
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box
     body:
       encoding: US-ASCII
       string: ''
@@ -63,6 +65,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_delete_provider.yml
+++ b/spec/cassettes/can_delete_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -52,7 +54,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 23:07:55 GMT
 - request:
     method: delete
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox
     body:
       encoding: US-ASCII
       string: ''
@@ -61,6 +63,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_delete_version.yml
+++ b/spec/cassettes/can_delete_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -53,7 +55,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 22:28:26 GMT
 - request:
     method: delete
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0
     body:
       encoding: US-ASCII
       string: ''
@@ -62,6 +64,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_fetch_box.yml
+++ b/spec/cassettes/can_fetch_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/example
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_fetch_provider.yml
+++ b/spec/cassettes/can_fetch_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_fetch_user.yml
+++ b/spec/cassettes/can_fetch_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/user/atlas-ruby?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/user/atlas-ruby
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_fetch_version.yml
+++ b/spec/cassettes/can_fetch_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_release_version.yml
+++ b/spec/cassettes/can_release_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -53,7 +55,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 23:16:29 GMT
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/release?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/release
     body:
       encoding: US-ASCII
       string: ''
@@ -62,6 +64,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_revoke_version.yml
+++ b/spec/cassettes/can_revoke_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -53,7 +55,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 23:17:50 GMT
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/revoke?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/revoke
     body:
       encoding: US-ASCII
       string: ''
@@ -62,6 +64,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_update_box.yml
+++ b/spec/cassettes/can_update_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -54,7 +56,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 21:36:50 GMT
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box
     body:
       encoding: UTF-8
       string: '{"box":{"created_at":"2018-03-18 21:19:25 UTC","updated_at":"2018-03-18
@@ -66,6 +68,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_update_provider.yml
+++ b/spec/cassettes/can_update_provider.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -52,7 +54,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 23:01:32 GMT
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/virtualbox
     body:
       encoding: UTF-8
       string: '{"provider":{"name":"vmware_desktop","original_url":null,"created_at":"2018-03-18
@@ -62,6 +64,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_update_version.yml
+++ b/spec/cassettes/can_update_version.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -52,7 +54,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 22:22:56 GMT
 - request:
     method: put
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0
     body:
       encoding: UTF-8
       string: '{"version":{"version":"1.0.0","status":"unreleased","created_at":"2018-03-18
@@ -63,6 +65,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/cassettes/can_upload_file.yml
+++ b/spec/cassettes/can_upload_file.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/parallels?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/parallels
     body:
       encoding: US-ASCII
       string: ''
@@ -11,6 +11,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200
@@ -52,7 +54,7 @@ http_interactions:
   recorded_at: Sun, 18 Mar 2018 23:05:32 GMT
 - request:
     method: get
-    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/parallels/upload?access_token=test-token
+    uri: https://app.vagrantup.com/api/v1/box/atlas-ruby/new-box/version/1.0.0/provider/parallels/upload
     body:
       encoding: US-ASCII
       string: ''
@@ -61,6 +63,8 @@ http_interactions:
       - Atlas-Ruby/1.6.0
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer test-token
   response:
     status:
       code: 200

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe Atlas::Configuration do
-  let(:config) { Atlas::Configuration.new access_token: 'abc' }
+  let(:config) { Atlas::Configuration.new(token: "abc") }
 
-  it 'has a full set of configured values' do
-    expect(config.access_token).to eq 'abc'
+  it "has a full set of configured values" do
+    expect(config.token).to eq "abc"
   end
 
-  it 'has a string representation' do
+  it "has a string representation" do
     expect(config.to_s).to be_a String
     # looks for a pattern that looks like:
     #   #<Core::Configuration:70239258795920 stripe_token=a>
@@ -16,8 +16,37 @@ describe Atlas::Configuration do
 (?=>?|\s[a-z_=]*\s?[a-z_=]*>)/)
   end
 
-  it 'has a hash representation' do
+  it "has a hash representation" do
     expect(config.to_h).to be_a Hash
-    expect(config.to_h[:access_token]).to eq 'abc'
+    expect(config.to_h[:token]).to eq "abc"
+  end
+
+  describe "deprecated options" do
+    it "shows a warning when initialized" do
+      warning_output = "WARNING: Setting the `:access_token` option " \
+                       "is deprecated, use `:token` instead\n"
+
+      expect do
+        described_class.new(access_token: "abc")
+      end.to output(warning_output).to_stderr
+    end
+
+    it "shows a warning when assigned" do
+      warning_output = "WARNING: Setting the `:access_token` option " \
+                       "is deprecated, use `:token` instead\n"
+
+      config = described_class.new
+
+      expect do
+        config.access_token = "abc"
+      end.to output(warning_output).to_stderr
+    end
+    it "assigns to the closest alternative" do
+      allow($stderr).to receive(:write) # supress stderr
+
+      config = described_class.new(access_token: "abc")
+
+      expect(config.token).to eq("abc")
+    end
   end
 end

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Atlas::BoxProvider do
   before do
     Atlas.configure do |config|
-      config.access_token = 'test-token'
+      config.token = "test-token"
     end
   end
 

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Atlas::User do
   before do
     Atlas.configure do |config|
-      config.access_token = 'test-token'
+      config.token = "test-token"
     end
   end
 

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Atlas::BoxVersion do
   before do
     Atlas.configure do |config|
-      config.access_token = 'test-token'
+      config.token = "test-token"
     end
   end
 


### PR DESCRIPTION
* Atlas now takes a `token`, rather than `access_token` configuration
  option.
* If the old `access_token` option is provided, a warning is shown.
* Updates the cassettes to use the new style.